### PR TITLE
Amend :Extract to use ember-cli codegen conventions

### DIFF
--- a/autoload/ember_tools/extract.vim
+++ b/autoload/ember_tools/extract.vim
@@ -18,6 +18,10 @@ function! ember_tools#extract#Run(start_line, end_line, component_name)
     elseif g:ember_tools_extract_behaviour == 'component-dir'
       let component_file = 'app/components/'.component_name.'/component.'.ember_tools#LogicExtension()
       let template_file  = 'app/components/'.component_name.'/template.'.ember_tools#TemplateExtension()
+    else 
+      echoerr 'Invalid value for setting g:ember_tools_extract_behaviour: "'.g:ember_tools_extract_behaviour.'". '. 
+                \'Valid values: "separate-template", "component-dir"'
+      return
     endif
 
     if ember_tools#util#Filereadable(template_file)

--- a/autoload/ember_tools/extract.vim
+++ b/autoload/ember_tools/extract.vim
@@ -1,4 +1,10 @@
 function! ember_tools#extract#Run(start_line, end_line, component_name)
+  function! Create_unless_exists(dirname) abort
+    if !isdirectory(a:dirname)
+      call mkdir(a:dirname, 'p')
+    endif
+  endfunction
+
   if !exists('b:ember_root')
     return
   endif
@@ -11,8 +17,10 @@ function! ember_tools#extract#Run(start_line, end_line, component_name)
     let end_line       = a:end_line
     let component_name = split(a:component_name, ' ')[0]
     let base_indent    = indent(start_line)
+    let template_dir   = 'app/templates/components'
+    let template_file  = template_dir.'/'.component_name.'.'.ember_tools#TemplateExtension()
 
-    let template_file = 'app/components/'.component_name.'/template.'.ember_tools#TemplateExtension()
+    call Create_unless_exists(template_dir)
 
     if ember_tools#util#Filereadable(template_file)
       echoerr 'File "'.template_file.'" already exists'
@@ -43,8 +51,8 @@ function! ember_tools#extract#Run(start_line, end_line, component_name)
             \ "`export default component;`",
             \ ]
 
-      call mkdir('app/components/'.component_name, 'p')
-      call writefile(component_lines, 'app/components/'.component_name.'/component.coffee')
+      call Create_unless_exists('app/components')
+      call writefile(component_lines, 'app/components/'.component_name.'.coffee')
     else " javascript
       let component_lines = [
             \ "import Ember from 'ember';",
@@ -54,8 +62,8 @@ function! ember_tools#extract#Run(start_line, end_line, component_name)
             \ "});",
             \ ]
 
-      call mkdir('app/components/'.component_name, 'p')
-      call writefile(component_lines, 'app/components/'.component_name.'/component.js')
+      call Create_unless_exists('app/components')
+      call writefile(component_lines, 'app/components/'.component_name.'.js')
     endif
 
     call writefile(partial_lines, template_file)

--- a/doc/ember_tools.txt
+++ b/doc/ember_tools.txt
@@ -249,6 +249,29 @@ general-purpose callback. There's also a few invocations of the plugin's
 public API, which, unfortunately, you would have to read the source code to
 understand.
 
+                                               *g:ember_tools_extract_behaviour*
+>
+    let g:ember_tools_extract_behaviour = 'component-dir'
+<
+Default value: "separate-template"
+
+This setting controls the behaviour of `:Extract` regarding what kind of
+files to generate and where. The options are:
+
+- "separate-template" (the default):
+>
+    Component file: app/components/<component-name>.js
+    Template file:  app/templates/components/<component-name>.hbs
+<
+- "component-dir"
+>
+    Component file: app/components/<component-name>/component.js
+    Template file:  app/components/<component-name>/template.hbs
+<
+The file extensions might not be "js" and "hbs", depending on what the current
+filetype is and what other settings are set to.
+
+
 ==============================================================================
 INTERNALS                                                *ember_tools-internals*
 

--- a/plugin/ember_tools.vim
+++ b/plugin/ember_tools.vim
@@ -18,6 +18,11 @@ if !exists('g:ember_tools_default_template_filetype')
   let g:ember_tools_default_template_filetype = 'handlebars'
 endif
 
+" possible values: separate-template, component-dir
+if !exists('g:ember_tools_extract_behaviour')
+  let g:ember_tools_extract_behaviour = 'separate-template'
+endif
+
 augroup ember_tools
   autocmd!
 

--- a/spec/plugin/extract_spec.rb
+++ b/spec/plugin/extract_spec.rb
@@ -23,10 +23,10 @@ describe ":Extract" do
       # force sync
       vim.command('echo')
 
-      expect(File.exists?('app/components/example-component/component.js')).to be_truthy
-      expect(File.exists?('app/components/example-component/template.hbs')).to be_truthy
+      expect(File.exists?('app/components/example-component.js')).to be_truthy
+      expect(File.exists?('app/templates/components/example-component.hbs')).to be_truthy
 
-      expect(current_file).to eq 'app/components/example-component/template.hbs'
+      expect(current_file).to eq 'app/templates/components/example-component.hbs'
 
       expect_file_contents current_file, <<-EOF
         <div class="second">
@@ -62,10 +62,10 @@ describe ":Extract" do
       # force sync
       vim.command('echo')
 
-      expect(File.exists?('app/components/example-component/component.coffee')).to be_truthy
-      expect(File.exists?('app/components/example-component/template.emblem')).to be_truthy
+      expect(File.exists?('app/components/example-component.coffee')).to be_truthy
+      expect(File.exists?('app/templates/components/example-component.emblem')).to be_truthy
 
-      expect(current_file).to eq 'app/components/example-component/template.emblem'
+      expect(current_file).to eq 'app/templates/components/example-component.emblem'
 
       expect_file_contents current_file, <<-EOF
         .second

--- a/spec/plugin/extract_spec.rb
+++ b/spec/plugin/extract_spec.rb
@@ -4,10 +4,12 @@ describe ":Extract" do
   after :each do
     # remove extra splits
     vim.command('only')
+    # reset to default settings
+    vim.command('let g:ember_tools_extract_behaviour = "separate-template"')
   end
 
   describe "javascript/hbs" do
-    specify "extract a template to a component" do
+    def perform_extract
       edit_file 'app/templates/example-template.hbs', <<-EOF
         <div class="first">
           <div class="second">
@@ -22,6 +24,10 @@ describe ":Extract" do
 
       # force sync
       vim.command('echo')
+    end
+
+    specify "extract a template to a component" do
+      perform_extract
 
       expect(File.exists?('app/components/example-component.js')).to be_truthy
       expect(File.exists?('app/templates/components/example-component.hbs')).to be_truthy
@@ -39,6 +45,17 @@ describe ":Extract" do
           {{example-component}}
         </div>
       EOF
+    end
+
+    specify "extract a template to a component directory" do
+      vim.command('let g:ember_tools_extract_behaviour = "component-dir"')
+
+      perform_extract
+
+      expect(File.exists?('app/components/example-component/component.js')).to be_truthy
+      expect(File.exists?('app/components/example-component/template.hbs')).to be_truthy
+
+      expect(current_file).to eq 'app/components/example-component/template.hbs'
     end
   end
 


### PR DESCRIPTION
Given the command `:Extract my-component`, this change will, instead of generating a `app/components/my-component` dir with `component.js` and `template.hbs` files, generate the following files:

* `app/components/my-component.js`
* `app/templates/components/my-component.hbs`

This will alter the :Extract function to have basically the same behaviour as `ember generate component my-component` with no further args, which seems to me to be the correct default (until the Great Module Unification, at which time anything like this will have to be revisited anyway).

Please note: this is the first line of vimscript I've ever done, so if there's something completely crazy in there, that's why!