### PR TITLE
Allow finding block-param type component with opening tag '{{#...'

### DIFF
--- a/autoload/ember_tools/gf.vim
+++ b/autoload/ember_tools/gf.vim
@@ -113,7 +113,7 @@ function! ember_tools#gf#TemplateComponent()
     return ''
   endif
 
-  if !ember_tools#search#UnderCursor('^\s*\%(=\|{{\)\{}\s*\zs\k\+')
+  if !ember_tools#search#UnderCursor('^\s*\%(=\|{{\#\|{{\)\{}\s*\zs\k\+')
     return ''
   endif
 

--- a/autoload/ember_tools/gf.vim
+++ b/autoload/ember_tools/gf.vim
@@ -113,7 +113,7 @@ function! ember_tools#gf#TemplateComponent()
     return ''
   endif
 
-  if !ember_tools#search#UnderCursor('^\s*\%(=\|{{\#\|{{\)\{}\s*\zs\k\+')
+  if !ember_tools#search#UnderCursor('^\s*\%(=\|{{#\|{{\)\{}\s*\zs\k\+')
     return ''
   endif
 

--- a/spec/plugin/gf_spec.rb
+++ b/spec/plugin/gf_spec.rb
@@ -144,6 +144,22 @@ describe "gf mapping" do
       expect(current_file).to eq 'app/pods/foo/bar-baz/template.hbs'
     end
 
+    specify "finding a component with block expression" do
+      touch_file 'app/components/foo/bar-baz/template.hbs'
+      edit_file 'app/templates/example.hbs', <<-EOF
+      <p>
+        {{#foo/bar-baz param1=something}}
+          <p>Foo Bar</p>
+        {{/foo/bar-baz}}
+      </p>
+      EOF
+      vim.search 'foo/bar-baz'
+
+      vim.normal 'gf'
+
+      expect(current_file).to eq 'app/components/foo/bar-baz/template.hbs'
+    end
+
     specify "finding a controller action" do
       edit_file 'app/controllers/foo.js', <<-EOF
         export default Ember.Controller.extend({


### PR DESCRIPTION
This PR is to allow finding (**gf**) a component with its name wrapped in {{#foo/bar-baz}}...{{/foo/bar-baz}}.

This syntax is used when having a component with block params (https://guides.emberjs.com/v2.7.0/components/block-params/).

Additional opening pattern has been added to allow the block params pattern and one additional test has been added to test this functionality.