### PR TITLE
Fix looking up components without template file in pod structure

### DIFF
--- a/autoload/ember_tools/gf.vim
+++ b/autoload/ember_tools/gf.vim
@@ -327,10 +327,10 @@ function! s:FindComponentLogic(component_name)
   let existing_file = ember_tools#ExistingLogicFile('app/components/'.a:component_name.'/component')
   if existing_file != '' | return existing_file | endif
 
-  let existing_file = ember_tools#ExistingTemplateFile('app/pods/'.a:component_name.'/component')
+  let existing_file = ember_tools#ExistingLogicFile('app/pods/'.a:component_name.'/component')
   if existing_file != '' | return existing_file | endif
 
-  let existing_file = ember_tools#ExistingTemplateFile('app/pods/components/'.a:component_name.'/component')
+  let existing_file = ember_tools#ExistingLogicFile('app/pods/components/'.a:component_name.'/component')
   if existing_file != '' | return existing_file | endif
 
   return ''

--- a/spec/plugin/gf_spec.rb
+++ b/spec/plugin/gf_spec.rb
@@ -172,6 +172,20 @@ describe "gf mapping" do
       expect(current_file).to eq 'app/pods/foo/bar-baz/template.hbs'
     end
 
+    specify "finding a component without a template file within a pod structure" do
+      touch_file 'app/pods/foo/bar-baz/component.js'
+      edit_file 'app/templates/example.hbs', <<-EOF
+        <p>
+          {{foo/bar-baz param1=something}}
+        </p>
+      EOF
+      vim.search 'foo/bar-baz'
+
+      vim.normal 'gf'
+
+      expect(current_file).to eq 'app/pods/foo/bar-baz/component.js'
+    end
+
     specify "finding a component with block expression" do
       touch_file 'app/components/foo/bar-baz/template.hbs'
       edit_file 'app/templates/example.hbs', <<-EOF


### PR DESCRIPTION
This PR fixes a bug where **gf** would not find a `component.js` for components that do not have a template file within a pod structure.